### PR TITLE
Replace "Fusion" with "Quantum".

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![](https://img.shields.io/badge/discord.js-v12.0.0--dev-blue.svg?logo=npm)](https://discord.js.org)
 
 ### Highlights
-Fusion offers (non-exhaustive list):
+Quantum offers (non-exhaustive list):
 *   ✉️ Coming soon, support for commands in direct messages,
 *   😀 Commands made pleasant thanks to the many emojis,
 *   ⚙️ Server configuration (prefix, starboard, etc...),
-Fusion also adds **a new mention** like `@everyone` and `@here`, which allows you to pick a random member of the server!
+Quantum also adds **a new mention** like `@everyone` and `@here`, which allows you to pick a random member of the server!
 
 ### Commands
-Fusion has a ton of features, with **7 main categories**:
+Quantum has a ton of features, with **7 main categories**:
 
 *   🌍 **General:** `reverse`, `search`, `encrypt`, `decrypt`, `ping`
 *   🛠️ **Moderation:** `ban`, `kick`, `warn`, `clear`, `avatar`, `profile`, `server`, `someone`, `rr-add`, `starboard` with a few more extra's,
@@ -20,7 +20,7 @@ Fusion has a ton of features, with **7 main categories**:
 
 ## Links
 *   [Discord](https://discord.gg/xMgSqyb)
-*   [Github](https://github.com/SoVieNTs/Fusion/)
+*   [GitHub](https://github.com/SoVieNTs/Fusion/)
 
 #### Partnered Servers!
 [![](https://img.shields.io/discord/737456018627362857.svg?logo=discord&colorB=7289DA)](https://discord.gg/azFnW2E)


### PR DESCRIPTION
The readme contained the previous bot name in the readme document, Thous we should update this to "Quantum" so that people don't end up getting confused with another bot.